### PR TITLE
Feature/add kieslerkreis to resultspage

### DIFF
--- a/components/AnalysisForm/index.js
+++ b/components/AnalysisForm/index.js
@@ -38,6 +38,16 @@ export default function AnalysisForm({
   typeOfAnalysis,
   allActionInterpretations,
 }) {
+  const [kieslerkreisData, setKieslerkreisData] = useState([
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  ]);
   const analysisKeys = allAnalysisKeys[typeOfAnalysis];
   const analysisHeadlines = allAnalysisFormHeadlines[typeOfAnalysis];
 
@@ -234,7 +244,11 @@ export default function AnalysisForm({
                 name={analysisKey}
                 id={analysisKey}
               />
-              <KieslerKreis />
+              <KieslerKreis
+                editMode="true"
+                kieslerkreisData={kieslerkreisData}
+                setKieslerkreisData={setKieslerkreisData}
+              />
             </EntryContent>
           );
         }

--- a/components/AnalysisForm/index.js
+++ b/components/AnalysisForm/index.js
@@ -246,6 +246,30 @@ export default function AnalysisForm({
               />
               <KieslerKreis
                 editMode="true"
+                analysisKey={analysisKey}
+                kieslerkreisData={kieslerkreisData}
+                setKieslerkreisData={setKieslerkreisData}
+              />
+            </EntryContent>
+          );
+        }
+        if (analysisKey === "behaviorChange") {
+          return (
+            <EntryContent>
+              <ContentHeadline htmlFor={analysisKey}>
+                {analysisHeadlines[analysisKey].title}
+              </ContentHeadline>
+              <p>{analysisHeadlines[analysisKey].description}</p>
+              <EntryInput
+                long
+                required
+                type="text"
+                name={analysisKey}
+                id={analysisKey}
+              />
+              <KieslerKreis
+                editMode="true"
+                analysisKey={analysisKey}
                 kieslerkreisData={kieslerkreisData}
                 setKieslerkreisData={setKieslerkreisData}
               />

--- a/components/Entry/index.js
+++ b/components/Entry/index.js
@@ -14,7 +14,9 @@ export default function Entry({
 }) {
   const { type } = data;
   const analysisKeys = allAnalysisKeys[type];
-
+  const [kieslerkreisData, setKieslerkreisData] = useState(
+    JSON.parse(data.kieslerkreis)
+  );
   function handleSubmit(event) {
     event.preventDefault();
     const formData = new FormData(event.target);
@@ -66,6 +68,8 @@ export default function Entry({
                 editMode={editMode}
                 updatedData={updatedData}
                 setUpdatedData={setUpdatedData}
+                kieslerkreisData={kieslerkreisData}
+                setKieslerkreisData={setKieslerkreisData}
               >
                 {allAnalysisEntryHeadings[analysisKey]}
               </EntryContentBlock>
@@ -82,6 +86,8 @@ export default function Entry({
               editMode={editMode}
               updatedData={updatedData}
               setUpdatedData={setUpdatedData}
+              kieslerkreisData={kieslerkreisData}
+              setKieslerkreisData={setKieslerkreisData}
             >
               {allAnalysisEntryHeadings[analysisKey]}
             </EntryContentBlock>

--- a/components/Entry/index.js
+++ b/components/Entry/index.js
@@ -26,7 +26,7 @@ export default function Entry({
       date: data.date,
     };
     dataset.interpretations = Object.entries(dataset)
-      .filter(([key, value]) => key.startsWith("interpretation "))
+      .filter(([key, value]) => key.startsWith("interpretations "))
       .map(([key, value]) => {
         const id = uid();
         delete dataset[key];
@@ -48,9 +48,6 @@ export default function Entry({
   }
 
   const [updatedData, setUpdatedData] = useState(data);
-  const [kieslerkreisData, setKieslerkreisData] = useState(
-    JSON.parse(updatedData.kieslerkreis)
-  );
 
   return (
     <>
@@ -68,8 +65,6 @@ export default function Entry({
                 editMode={editMode}
                 updatedData={updatedData}
                 setUpdatedData={setUpdatedData}
-                kieslerkreisData={kieslerkreisData}
-                setKieslerkreisData={setKieslerkreisData}
               >
                 {allAnalysisEntryHeadings[analysisKey]}
               </EntryContentBlock>
@@ -86,8 +81,6 @@ export default function Entry({
               editMode={editMode}
               updatedData={updatedData}
               setUpdatedData={setUpdatedData}
-              kieslerkreisData={kieslerkreisData}
-              setKieslerkreisData={setKieslerkreisData}
             >
               {allAnalysisEntryHeadings[analysisKey]}
             </EntryContentBlock>

--- a/components/Entry/index.js
+++ b/components/Entry/index.js
@@ -14,9 +14,6 @@ export default function Entry({
 }) {
   const { type } = data;
   const analysisKeys = allAnalysisKeys[type];
-  const [kieslerkreisData, setKieslerkreisData] = useState(
-    JSON.parse(data.kieslerkreis)
-  );
   function handleSubmit(event) {
     event.preventDefault();
     const formData = new FormData(event.target);
@@ -51,6 +48,9 @@ export default function Entry({
   }
 
   const [updatedData, setUpdatedData] = useState(data);
+  const [kieslerkreisData, setKieslerkreisData] = useState(
+    JSON.parse(updatedData.kieslerkreis)
+  );
 
   return (
     <>

--- a/components/EntryContentBlock/index.js
+++ b/components/EntryContentBlock/index.js
@@ -5,6 +5,7 @@ import { styled } from "styled-components";
 import Button from "../Button";
 import { uid } from "uid";
 import { confirmAlert } from "react-confirm-alert";
+import KieslerKreis from "../KieslerKreis";
 
 const InterpretationListItem = styled.li`
   position: relative;
@@ -21,6 +22,8 @@ export default function EntryContentBlock({
   analysisKey,
   updatedData,
   setUpdatedData,
+  kieslerkreisData,
+  setKieslerkreisData,
 }) {
   function handleChange(analysisKey, value) {
     setUpdatedData((prevData) => ({ ...prevData, [analysisKey]: value }));
@@ -148,6 +151,25 @@ export default function EntryContentBlock({
             ))}
         </EntryContent>
       );
+    } else if (analysisKey === "behavior") {
+      return (
+        <EntryContent>
+          <ContentHeadline htmlFor={analysisKey}>{children}</ContentHeadline>
+          <EntryInput
+            long
+            type="text"
+            name={analysisKey}
+            id={analysisKey}
+            value={updatedData[analysisKey]}
+            onChange={(event) => handleChange(analysisKey, event.target.value)}
+          />
+          <KieslerKreis
+            editMode={editMode}
+            kieslerkreisData={kieslerkreisData}
+            setKieslerkreisData={setKieslerkreisData}
+          />
+        </EntryContent>
+      );
     } else {
       return (
         <EntryContent>
@@ -164,23 +186,40 @@ export default function EntryContentBlock({
       );
     }
   } else {
-    return (
-      <>
-        <EntryContent>
-          <ContentHeadline>{children}</ContentHeadline>
-          {Array.isArray(updatedData[analysisKey]) ? (
-            <ol>
-              {updatedData[analysisKey].map(
-                ({ id, interpretation, revision }) => (
-                  <li key={id}>{interpretation ? interpretation : revision}</li>
-                )
-              )}
-            </ol>
-          ) : (
+    if (analysisKey === "behavior") {
+      return (
+        <>
+          <EntryContent>
+            <ContentHeadline>{children}</ContentHeadline>
             <p>{updatedData[analysisKey]}</p>
-          )}
-        </EntryContent>
-      </>
-    );
+            <KieslerKreis
+              kieslerkreisData={kieslerkreisData}
+              setKieslerkreisData={setKieslerkreisData}
+            />
+          </EntryContent>
+        </>
+      );
+    } else {
+      return (
+        <>
+          <EntryContent>
+            <ContentHeadline>{children}</ContentHeadline>
+            {Array.isArray(updatedData[analysisKey]) ? (
+              <ol>
+                {updatedData[analysisKey].map(
+                  ({ id, interpretation, revision }) => (
+                    <li key={id}>
+                      {interpretation ? interpretation : revision}
+                    </li>
+                  )
+                )}
+              </ol>
+            ) : (
+              <p>{updatedData[analysisKey]}</p>
+            )}
+          </EntryContent>
+        </>
+      );
+    }
   }
 }

--- a/components/EntryContentBlock/index.js
+++ b/components/EntryContentBlock/index.js
@@ -164,6 +164,27 @@ export default function EntryContentBlock({
             onChange={(event) => handleChange(analysisKey, event.target.value)}
           />
           <KieslerKreis
+            analysisKey={analysisKey}
+            editMode={editMode}
+            kieslerkreisData={kieslerkreisData}
+            setKieslerkreisData={setKieslerkreisData}
+          />
+        </EntryContent>
+      );
+    } else if (analysisKey === "behaviorChange") {
+      return (
+        <EntryContent>
+          <ContentHeadline htmlFor={analysisKey}>{children}</ContentHeadline>
+          <EntryInput
+            long
+            type="text"
+            name={analysisKey}
+            id={analysisKey}
+            value={updatedData[analysisKey]}
+            onChange={(event) => handleChange(analysisKey, event.target.value)}
+          />
+          <KieslerKreis
+            analysisKey={analysisKey}
             editMode={editMode}
             kieslerkreisData={kieslerkreisData}
             setKieslerkreisData={setKieslerkreisData}
@@ -193,6 +214,21 @@ export default function EntryContentBlock({
             <ContentHeadline>{children}</ContentHeadline>
             <p>{updatedData[analysisKey]}</p>
             <KieslerKreis
+              analysisKey={analysisKey}
+              kieslerkreisData={kieslerkreisData}
+              setKieslerkreisData={setKieslerkreisData}
+            />
+          </EntryContent>
+        </>
+      );
+    } else if (analysisKey === "behaviorChange") {
+      return (
+        <>
+          <EntryContent>
+            <ContentHeadline>{children}</ContentHeadline>
+            <p>{updatedData[analysisKey]}</p>
+            <KieslerKreis
+              analysisKey={analysisKey}
               kieslerkreisData={kieslerkreisData}
               setKieslerkreisData={setKieslerkreisData}
             />

--- a/components/EntryContentBlock/index.js
+++ b/components/EntryContentBlock/index.js
@@ -22,8 +22,6 @@ export default function EntryContentBlock({
   analysisKey,
   updatedData,
   setUpdatedData,
-  kieslerkreisData,
-  setKieslerkreisData,
 }) {
   function handleChange(analysisKey, value) {
     setUpdatedData((prevData) => ({ ...prevData, [analysisKey]: value }));
@@ -166,8 +164,7 @@ export default function EntryContentBlock({
           <KieslerKreis
             analysisKey={analysisKey}
             editMode={editMode}
-            kieslerkreisData={kieslerkreisData}
-            setKieslerkreisData={setKieslerkreisData}
+            kieslerkreisData={updatedData.behaviorKieslerkreis}
           />
         </EntryContent>
       );
@@ -186,8 +183,7 @@ export default function EntryContentBlock({
           <KieslerKreis
             analysisKey={analysisKey}
             editMode={editMode}
-            kieslerkreisData={kieslerkreisData}
-            setKieslerkreisData={setKieslerkreisData}
+            kieslerkreisData={updatedData.behaviorChangeKieslerkreis}
           />
         </EntryContent>
       );
@@ -215,8 +211,7 @@ export default function EntryContentBlock({
             <p>{updatedData[analysisKey]}</p>
             <KieslerKreis
               analysisKey={analysisKey}
-              kieslerkreisData={kieslerkreisData}
-              setKieslerkreisData={setKieslerkreisData}
+              kieslerkreisData={updatedData.behaviorKieslerkreis}
             />
           </EntryContent>
         </>
@@ -229,8 +224,7 @@ export default function EntryContentBlock({
             <p>{updatedData[analysisKey]}</p>
             <KieslerKreis
               analysisKey={analysisKey}
-              kieslerkreisData={kieslerkreisData}
-              setKieslerkreisData={setKieslerkreisData}
+              kieslerkreisData={updatedData.behaviorChangeKieslerkreis}
             />
           </EntryContent>
         </>

--- a/components/KieslerKreis/index.js
+++ b/components/KieslerKreis/index.js
@@ -51,24 +51,17 @@ const kieslerKreisDescription = [
   },
 ];
 
-export default function KieslerKreis() {
-  const [strengthOfCategory, setStrengthOfCategory] = useState("");
+export default function KieslerKreis({
+  kieslerkreisData,
+  setKieslerkreisData,
+  editMode,
+}) {
   const strengthDescriptions = [
     { number: 1, text: "schwach ausgeprägt" },
     { number: 2, text: "mittlere Ausprägung" },
     { number: 3, text: "stark ausgeprägt" },
   ];
-  const [pointData, setPointData] = useState([
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-  ]);
-  const [descriptionText, setDescriptionText] = useState({});
+
   const chartData = {
     labels: [
       ["Dominant", "Offen"],
@@ -84,7 +77,7 @@ export default function KieslerKreis() {
       {
         type: "radar",
         label: "Einschätzung",
-        data: pointData,
+        data: kieslerkreisData,
         backgroundColor: "rgba(255, 99, 132, 0.2)",
         borderColor: "rgba(255, 99, 132, 1)",
         borderWidth: 2,
@@ -93,8 +86,7 @@ export default function KieslerKreis() {
       },
     ],
   };
-
-  const options = {
+  let options = {
     scale: { min: 0, max: 3, stepSize: 1 },
     scales: {
       r: {
@@ -107,84 +99,103 @@ export default function KieslerKreis() {
       legend: {
         display: false,
       },
-      tooltip: {
-        enabled: false,
-      },
-    },
-
-    onClick: (event, element, chart) => {
-      const x = event.x;
-      const y = event.y;
-      const center = { x: chart.scales.r.xCenter, y: chart.scales.r.yCenter };
-      const distance = Math.sqrt(
-        Math.pow(x - center.x, 2) + Math.pow(y - center.y, 2)
-      );
-      const angle = Math.atan2(y - center.y, x - center.x);
-      const rScale = chart.scales.r;
-      const distanceMax = rScale.getDistanceFromCenterForValue(rScale.max);
-      const distanceWidth = distanceMax / 6;
-      const distance0 = distanceWidth;
-      const distance1 = distanceWidth * 3;
-      const distance2 = distanceWidth * 5;
-      const distance3 = distanceWidth * 7;
-
-      const value =
-        distance < distance0
-          ? 0
-          : distance >= distance0 && distance < distance1
-          ? 1
-          : distance >= distance1 && distance < distance2
-          ? 2
-          : distance >= distance2 && distance < distance3
-          ? 3
-          : null;
-
-      const getAxisIndex = (angle) => {
-        if (angle >= -0.405 && angle < 0.405) return 2;
-        if (angle >= 0.405 && angle < 1.215) return 3;
-        if (angle >= 1.215 && angle < 2.025) return 4;
-        if (angle >= 2.025 && angle < 2.835) return 5;
-        if (
-          (angle >= 2.835 && angle <= 3.14) ||
-          (angle >= -3.14 && angle < -2.835)
-        )
-          return 6;
-        if (angle >= -2.835 && angle < -2.025) return 7;
-        if (angle >= -2.025 && angle < -1.215) return 0;
-        if (angle >= -1.215 && angle < -0.405) return 1;
-      };
-
-      const axisIndex = getAxisIndex(angle);
-
-      let axisPoints = [null, null, null, null, null, null, null, null];
-      axisPoints[axisIndex] = value;
-      if (value > 0) {
-        setPointData(axisPoints);
-        setDescriptionText(kieslerKreisDescription[axisIndex]);
-        setStrengthOfCategory(value);
-      } else {
-        setPointData([null, null, null, null, null, null, null, null]);
-        setDescriptionText({});
-        setStrengthOfCategory();
-      }
     },
   };
+  if (editMode) {
+    options = {
+      scale: { min: 0, max: 3, stepSize: 1 },
+      scales: {
+        r: {
+          max: 3,
+          min: 0,
+          stepSize: 1,
+        },
+      },
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          enabled: false,
+        },
+      },
 
+      onClick: (event, element, chart) => {
+        const x = event.x;
+        const y = event.y;
+        const center = { x: chart.scales.r.xCenter, y: chart.scales.r.yCenter };
+        const distance = Math.sqrt(
+          Math.pow(x - center.x, 2) + Math.pow(y - center.y, 2)
+        );
+        const angle = Math.atan2(y - center.y, x - center.x);
+        const rScale = chart.scales.r;
+        const distanceMax = rScale.getDistanceFromCenterForValue(rScale.max);
+        const distanceWidth = distanceMax / 6;
+        const distance0 = distanceWidth;
+        const distance1 = distanceWidth * 3;
+        const distance2 = distanceWidth * 5;
+        const distance3 = distanceWidth * 7;
+
+        const value =
+          distance < distance0
+            ? 0
+            : distance >= distance0 && distance < distance1
+            ? 1
+            : distance >= distance1 && distance < distance2
+            ? 2
+            : distance >= distance2 && distance < distance3
+            ? 3
+            : null;
+
+        const getAxisIndex = (angle) => {
+          if (angle >= -0.405 && angle < 0.405) return 2;
+          if (angle >= 0.405 && angle < 1.215) return 3;
+          if (angle >= 1.215 && angle < 2.025) return 4;
+          if (angle >= 2.025 && angle < 2.835) return 5;
+          if (
+            (angle >= 2.835 && angle <= 3.14) ||
+            (angle >= -3.14 && angle < -2.835)
+          )
+            return 6;
+          if (angle >= -2.835 && angle < -2.025) return 7;
+          if (angle >= -2.025 && angle < -1.215) return 0;
+          if (angle >= -1.215 && angle < -0.405) return 1;
+        };
+
+        const axisIndex = getAxisIndex(angle);
+
+        let axisPoints = [null, null, null, null, null, null, null, null];
+        axisPoints[axisIndex] = value;
+        if (value > 0) {
+          setKieslerkreisData(axisPoints);
+        } else {
+          setKieslerkreisData([null, null, null, null, null, null, null, null]);
+        }
+      },
+    };
+  }
+  const strengthOfCategory = kieslerkreisData.findIndex(
+    (value) => value !== null
+  );
+  const strengthDescription = strengthDescriptions.find(
+    (strengthDescription) =>
+      strengthDescription.number === kieslerkreisData[strengthOfCategory]
+  );
+  const descriptionText = kieslerKreisDescription[strengthOfCategory];
   return (
     <>
       <DiagrammContainer>
         <Radar data={chartData} options={options} />
       </DiagrammContainer>
-      {descriptionText.title && <p>Dein Verhalten war:</p>}
-      <h2>{descriptionText.title}</h2>
-      <p>
-        {strengthOfCategory &&
-          strengthDescriptions.filter(
-            (strengthDescription) =>
-              strengthDescription.number == strengthOfCategory
-          )[0].text}
-      </p>
-      <p>{descriptionText.description}</p>
+      {descriptionText && <p>Dein Verhalten war:</p>}
+      <h2>{descriptionText?.title}</h2>
+      <p>{strengthDescription?.text}</p>
+      <p>{descriptionText?.description}</p>
+      <input
+        type="hidden"
+        name="kieslerkreis"
+        value={JSON.stringify(kieslerkreisData)}
+      />
     </>
   );
 }

--- a/components/KieslerKreis/index.js
+++ b/components/KieslerKreis/index.js
@@ -53,10 +53,12 @@ const kieslerKreisDescription = [
 
 export default function KieslerKreis({
   kieslerkreisData,
-  setKieslerkreisData,
   editMode,
   analysisKey,
 }) {
+  const [kieslerkreisDataset, setKieslerkreisDataset] = useState(
+    JSON.parse(kieslerkreisData)
+  );
   const strengthDescriptions = [
     { number: 1, text: "schwach ausgeprägt" },
     { number: 2, text: "mittlere Ausprägung" },
@@ -78,7 +80,7 @@ export default function KieslerKreis({
       {
         type: "radar",
         label: "Einschätzung",
-        data: kieslerkreisData,
+        data: kieslerkreisDataset,
 
         borderWidth: 2,
         pointRadius: 30,
@@ -164,18 +166,27 @@ export default function KieslerKreis({
       let axisPoints = [null, null, null, null, null, null, null, null];
       axisPoints[axisIndex] = value;
       if (value > 0) {
-        setKieslerkreisData(axisPoints);
+        setKieslerkreisDataset(axisPoints);
       } else {
-        setKieslerkreisData([null, null, null, null, null, null, null, null]);
+        setKieslerkreisDataset([
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ]);
       }
     };
   }
-  const strengthOfCategory = kieslerkreisData.findIndex(
+  const strengthOfCategory = kieslerkreisDataset.findIndex(
     (value) => value !== null
   );
   const strengthDescription = strengthDescriptions.find(
     (strengthDescription) =>
-      strengthDescription.number === kieslerkreisData[strengthOfCategory]
+      strengthDescription.number === kieslerkreisDataset[strengthOfCategory]
   );
   const descriptionText = kieslerKreisDescription[strengthOfCategory];
   return (
@@ -202,7 +213,7 @@ export default function KieslerKreis({
             ? "behaviorChangeKieslerkreis"
             : null
         }
-        value={JSON.stringify(kieslerkreisData)}
+        value={JSON.stringify(kieslerkreisDataset)}
       />
     </>
   );

--- a/lib/initialEntries.js
+++ b/lib/initialEntries.js
@@ -11,6 +11,7 @@ const initialEntries = [
       { id: "3", interpretation: "I can't trust anyone" },
     ],
     behavior: "I stopped talking to my friend",
+    behaviorKieslerkreis: "[null,null,null,null,2,null,null,null]",
     actualResult: "We grew apart",
     desiredResult: "To resolve the argument and maintain the friendship",
     comparison: "The actual result was not what I desired",
@@ -24,6 +25,7 @@ const initialEntries = [
     ],
     actionInterpretation: "I am allowed to listen to my feelings",
     behaviorChange: "Talk to my friend and try to resolve the argument",
+    behaviorChangeKieslerkreis: "[1,null,null,null,null,null,null,null]",
     implementation: "I called my friend and we talked it out",
     transfer: "I will try to communicate better in future disagreements",
   },
@@ -32,6 +34,7 @@ const initialEntries = [
     type: "PastAnalysis",
     title: "TESTArgument with friend",
     date: "2022-10-01",
+    behaviorKieslerkreis: "[null,null,3,null,null,null,null,null]",
     description: "I had an argument with my friend",
     interpretations: [
       { id: "1", interpretation: "My friend doesn't care about me" },
@@ -45,6 +48,7 @@ const initialEntries = [
     revision: "My interpretation may have been incorrect",
     actionInterpretation: "My opinion has value",
     behaviorChange: "Talk to my friend and try to resolve the argument",
+    behaviorChangeKieslerkreis: "[null,null,null,2,null,null,null,null]",
     implementation: "I called my friend and we talked it out",
     transfer: "I will try to communicate better in future disagreements",
   },
@@ -53,6 +57,7 @@ const initialEntries = [
     type: "InnerSituationAnalysis",
     title: "Anxiety in social situations",
     date: "2022-11-15",
+    behaviorKieslerkreis: "[null,null,null,null,null,null,null,null]",
     description: "I feel anxious in social situations",
     interpretations: [
       { id: "1", interpretation: "People are judging me" },
@@ -73,6 +78,7 @@ const initialEntries = [
     ],
     actionInterpretation: "I am strong enough to overcome challenges",
     behaviorChange: "Try to attend social situations and challenge my thoughts",
+    behaviorChangeKieslerkreis: "[null,null,null,null,null,null,null,null]",
     implementation:
       "I attended a social event and realized people were not judging me",
     transfer: "I will try to challenge my thoughts in future social situations",
@@ -81,6 +87,7 @@ const initialEntries = [
     id: "3",
     type: "PastAnalysis",
     title: "Failed Exam",
+    behaviorKieslerkreis: "[null,null,null,null,null,null,null,null]",
     date: "2022-09-01",
     description: "I failed an important exam",
     interpretations: [
@@ -105,6 +112,7 @@ const initialEntries = [
     ],
     actionInterpretation: "I can learn and grow from my mistakes",
     behaviorChange: "Study harder and ask for help if needed",
+    behaviorChangeKieslerkreis: "[null,null,null,null,null,null,null,null]",
     implementation: "I studied harder and passed the next exam",
     transfer: "I will continue to study hard and ask for help if needed",
   },
@@ -113,6 +121,7 @@ const initialEntries = [
     type: "InnerSituationAnalysis",
     title: "Fear of public speaking",
     date: "2022-12-01",
+    behaviorKieslerkreis: "[null,null,null,3,null,null,null,null]",
     description: "I am afraid of public speaking",
     interpretations: [
       {
@@ -136,6 +145,7 @@ const initialEntries = [
     ],
     actionInterpretation: "",
     behaviorChange: "Practice public speaking and challenge my thoughts",
+    behaviorChangeKieslerkreis: "[null,null,null,null,null,null,null,2]",
     implementation:
       "I practiced public speaking and realized people were interested in what I had to say",
     transfer:
@@ -146,6 +156,7 @@ const initialEntries = [
     type: "FutureAnalysis",
     title: "Starting a new hobby",
     date: "2023-02-01",
+    behaviorKieslerkreis: "[null,null,null,2,null,null,null,null]",
     description: "I want to start a new hobby, painting",
     desiredResult: "To enjoy painting and improve my skills over time",
     behavior:
@@ -176,6 +187,7 @@ const initialEntries = [
     description: "I want to apply for a new job",
     desiredResult: "To get the job and feel fulfilled in my career",
     behavior: "Prepare for the interview and present myself well",
+    behaviorKieslerkreis: "[2,null,null,null,null,null,null,null]",
     interpretations: [
       { id: "1", interpretation: "I am capable and qualified for this job" },
       { id: "2", interpretation: "I have valuable skills to offer" },

--- a/pages/newanalysis/index.js
+++ b/pages/newanalysis/index.js
@@ -93,6 +93,7 @@ export default function NewAnalysis({
     handleAllEntriesChange([...allEntries, dataset]);
     addActionInterpretation(dataset.actionInterpretation);
     setDataset(dataset);
+    console.log(dataset);
     event.target.reset();
     router.push(`/entries/${dataset.id}`);
   }


### PR DESCRIPTION
# PR for [UserStory 22](https://github.com/vaupunkt/cbaspCompanion/issues/41) & [UserStory 23](https://github.com/vaupunkt/cbaspCompanion/issues/42)

As a user
I want to see in older analyses where I was on the Kieslerkreis
So that I can review my behaviour and learn from it

As an User
I want to edit my position on the kieslerkreis in older entries
So that I can change it if i made a mistake